### PR TITLE
Move configuration to user home

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "cSpell.words": [
+        "Phoenixfish",
+        "mkdir",
+        "mycategory",
+        "myprotocol",
+        "myprotocols",
+        "pfish",
+        "pydent"
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN pip3 install \
     cliff \
     pydent
  
-RUN mkdir /script
+RUN mkdir /script \
+    mkdir -p /script/config
 WORKDIR /script
 
 COPY ./pxfish .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX ?= ~
-VERSION = "0.0.1"
+VERSION = "0.0.2"
 
 all: install
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ where you specify the configuration-name, user-login, password and instance URL.
 A configuration name is simply a key to keep track of the login information for a particular Aquarium instance.
 (Each of these arguments have defaults that correspond to the local configuration.)
 
-*Note*: The `configure add` command will overwrite an existing login configuration, as shown in this example.
+*Note*: The `configure add` command will overwrite an existing login configuration.
 
 The most common use of `configure add` is to set up login configurations for different Aquarium instances.
 For instance, a user might have a `production` configuration in addition to the `local` configuration.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You must have Docker installed to run the script this way.
 
 ## Configuring
 
-The initial settings for pfish are to connect to a [local Aquarium instance](https://aquariumbio.github.io/aquarium-local/) using the default user login (`neptune`) and password (`aquarium`) at URL (`http://localhost/`).
+Initially, pfish is configured to connect to a [local Aquarium instance](https://aquariumbio.github.io/aquarium-local/) using the default user login (`neptune`) and password (`aquarium`) at URL (`http://localhost/`).
 So, if you are using that Aquarium user, you don't need to do anything to start with.
 
 However, if you use a different login, you'll want to change the login and password for this local instance.
@@ -41,6 +41,7 @@ pfish configure add -l <user-login> -p <user-password>
 
 with the new login name and password.
 
+This command is a shortened version of the full `configure add` command using default values for some of the arguments.
 The full `configure add` command is
 
 ```bash
@@ -64,28 +65,33 @@ pfish configure add -l <user-login> -p <user-password>
 
 uses the configuration name `local` and the URL `http://localhost/`.
 
-**Note**: the `configure add` command will overwrite an existing login configuration, as shown in this example.
+*Note*: The `configure add` command will overwrite an existing login configuration, as shown in this example.
 
-If you also want to be able to push/pull from your production instance, you should create a different login configuration with
-
-The most common use of `configure add` is to set up logins for different Aquarium instances.
+The most common use of `configure add` is to set up login configurations for different Aquarium instances.
 For instance, a user might have a `production` configuration in addition to the `local` configuration.
-The `local` configuration is used by default, and the other commands allow specifying the configuration that should be used.
+In this case, with they would use the above command giving the configuration name `production` with their login details for the production instance:
 
-You can set the default configuration with the command
+```bash
+pfish configure add -n production -l <user-login> -p <user-password> -u <instance-url>
+```
+
+With these settings, the `local` configuration is still used by default, but the `production` configuration can be specified when transferring protocols.
+
+If needed, the default configuration can be set with the command
 
 ```bash
 pfish configure set-default -n <config-name>
 ```
 
-which you might want to do if you do development on a staging server.
+which you might want to do if you do development on a staging instance rather than a local one.
 
 ## Commands
 
-The following commands work with files in the current working directory using the Aquarium instance in the default login configuration.
+All commands other than `configure` by default use the current working directory using the Aquarium instance in the default login configuration.
+These defaults can be overridden with the following options
 
-- To work in a subdirectory of the current working directory, use the option `-d <directory-name>`.
-- To use a different instance, specify the login configuration with the option `-n <config-name>`.
+- `-d <directory-name>` - use the named subdirectory of the current working directory.
+- `-n <config-name>` - use the named login configuration instead of the default.
 
 ### Create
 
@@ -97,7 +103,7 @@ The available create commands are:
    pfish create -c <category-name> -o <operation-type-name>
    ```
 
-2. [creating a library is not currently supported]
+2. [Creating a library is not currently supported. The work-around is to create the library in Aquarium and use pull.]
 
 ### Pull
 
@@ -115,13 +121,13 @@ The available pull commands are:
    pfish pull -c <category_name>
    ```
 
-3. Pull just one operation type
+3. Pull an operation type
 
    ```bash
    pfish pull -c <category_name> -o <operation_type_name>
    ```
 
-4. Pull one library
+4. Pull a library
 
    ```bash
    pfish pull -c <category_name> -l <library_name>
@@ -164,13 +170,14 @@ cd myprotocols
 ```
 
 You can then either create new protocols or pull existing ones from your Aquarium instance.
-Let's first create a protocol using the `create` command
+
+To create a new protocol, use the `create` command
 
 ```bash
 pfish create -c MyCategory -o MyProtocol
 ```
 
-which will create a protocol both in Aquarium and in the current directory.
+which will create the protocol both in Aquarium and in the current directory.
 The local files will be in the directory `mycategory`:
 
 ```bash
@@ -185,21 +192,20 @@ The local files will be in the directory `mycategory`:
             `-- protocol.rb
 ```
 
-Now make an initial git commit
+One the protocol is created, make an initial git commit of the new files with the commands
 
 ```bash
-git add mycategory
+git add mycategory/operation_types/myprotocol
 git commit -m "Add new definition for MyProtocol"
 ```
 
 and then you can edit the files.
 
-> Pfish mangles names to be lowercase with spaces changed to underscores.
+> Notice that pfish uses filenames that are the Aquarium names changed to all lowercase, and spaces changed to underscores.
 > The original names are captured in the `definition.json` file and used when protocols and libraries are pushed.
-> You do need to use the Aquarium names for libraries that you use.
+> You do need to use the Aquarium names for libraries in your protocol or library code.
 
-In the situation where you have protocol code already in Aquarium that you want to work with on disk, you can pull that code and add it to your git repository.
-
+To add protocol code already in Aquarium, use the pull command and add the files to the repository.
 For example, consider a `Cloning` category with the following structure
 
 - Libraries:

--- a/README.md
+++ b/README.md
@@ -8,128 +8,233 @@ You must have Docker installed to run the script this way.
 
 - Ensure you have a directory `~/bin`:
 
-```bash
-mkdir -p ~/bin
-```
+  ```bash
+  mkdir -p ~/bin
+  ```
 
 - Add `~/bin` to your PATH. How you do this depends on your the shell that you run.
 
 - Clone Parrotfish:
 
-```bash
-git clone https://github.com/klavinslab/pfish.git
-```
+  ```bash
+  git clone https://github.com/klavinslab/pfish.git
+  ```
 
 - Install the `pfish` script
 
-```bash
-cd pfish
-make install
-```
+  ```bash
+  cd pfish
+  make install
+  ```
 
-## For each project
+## Configuring
 
-[TODO: change this to running `pfish init`]
+The initial settings for pfish are to connect to a [local Aquarium instance](https://aquariumbio.github.io/aquarium-local/) using the default user login (`neptune`) and password (`aquarium`) at URL (`http://localhost/`).
+So, if you are using that Aquarium user, you don't need to do anything to start with.
 
-Create a directory for pfish repos, and copy the file `resources-template.py` in this repository to this directory.
-
-```bash
-mkdir /pfish/repos/directory # Absolute path, not a subdirectory of ParroPyTriFish
-cp resources-template.py /pfish/repos/directory/resources.py
-```
-
-and then change the values to match your Aquarium instance and account.
-It is currently set for the default Aquarium user `neptune`.
-
-Be sure to put resources.py into the .gitignore file if you put `/pfish/repos/directory` under version control.
-
-## Pulling Files from Aquarium
-
-- You will need to be in the same directory as `resources.py` to run `pfish`
+However, if you use a different login, you'll want to change the login and password for this local instance.
+To do this, use the command
 
 ```bash
-cd /pfish/repos/directory
+pfish configure add -l <user-login> -p <user-password>
 ```
 
-- If you would like to pull ALL files from you Aquarium Instance.
+with the new login name and password.
+
+The full `configure add` command is
 
 ```bash
-pfish pull -d <my_directory_name>
+pfish configure add -n <configuration-name> -l <user-login> -p <user-password> -u <instance-url>
 ```
 
-`pfish` will create `my_directory_name` if it doesn't exist.
+where you specify the configuration-name, user-login, password and instance URL.
+A configuration name is simply a key to keep track of the login information for a particular Aquarium instance.
+Each of these arguments have defaults that correspond to the local configuration:
 
-- If you would like to pull everything from one category/folder.
+- the default configuration name is `local`,
+- the login is `neptune`,
+- the password is `aquarium`, and
+- the URL is `http://localhost/`.
+
+So, the command for changing the local user from above
 
 ```bash
-pfish pull -d <my_directory_name> -c <category_name>
+pfish configure add -l <user-login> -p <user-password>
 ```
 
-- If you would like to pull just one operation type or library.
+uses the configuration name `local` and the URL `http://localhost/`.
+
+**Note**: the `configure add` command will overwrite an existing login configuration, as shown in this example.
+
+If you also want to be able to push/pull from your production instance, you should create a different login configuration with
+
+The most common use of `configure add` is to set up logins for different Aquarium instances.
+For instance, a user might have a `production` configuration in addition to the `local` configuration.
+The `local` configuration is used by default, and the other commands allow specifying the configuration that should be used.
+
+You can set the default configuration with the command
 
 ```bash
-pfish pull -d <my_directory_name> -c <category_name> -o <operation_type_name>
+pfish configure set-default -n <config-name>
 ```
+
+which you might want to do if you do development on a staging server.
+
+## Commands
+
+The following commands work with files in the current working directory using the Aquarium instance in the default login configuration.
+
+- To work in a subdirectory of the current working directory, use the option `-d <directory-name>`.
+- To use a different instance, specify the login configuration with the option `-n <config-name>`.
+
+### Create
+
+The available create commands are:
+
+1. Create an operation type
+
+   ```bash
+   pfish create -c <category-name> -o <operation-type-name>
+   ```
+
+2. [creating a library is not currently supported]
+
+### Pull
+
+The available pull commands are:
+
+1. Pull all libraries and operation types in the default Aquarium instance:
+
+   ```bash
+   pfish pull
+   ```
+
+2. Pull all operations and libraries from a category
+
+   ```bash
+   pfish pull -c <category_name>
+   ```
+
+3. Pull just one operation type
+
+   ```bash
+   pfish pull -c <category_name> -o <operation_type_name>
+   ```
+
+4. Pull one library
+
+   ```bash
+   pfish pull -c <category_name> -l <library_name>
+   ```
+
+### Push
+
+_Note_: You must create protocols and libraries using the `create` command before pushing them to Aquarium.
+
+The available push commands are:
+
+1. Push a category:
+
+   ```bash
+   pfish push -c <category_name>
+   ```
+
+2. Push a library:
+
+   ```bash
+   pfish push -c <category_name> -l <library_name>
+   ```
+
+3. Push an operation type
+
+   ```bash
+   pfish push -c <category_name> -o <operation_type_name>
+   ```
+
+## Developing protocols
+
+The strategy for working with protocols with pfish and git is to create the git repo and then use pfish from within the directory for the repository.
+
+The first step is to create a git repository.
+So, assuming you first initialize a `myprotocols` repo on GitHub, the commands would be
 
 ```bash
-pfish pull -d <my_directory_name> -c <category_name> -l <library_name>
+git clone <github-path-for-myprotocols>
+cd myprotocols
 ```
 
-### Pulling Example
-
-- Category: Cloning
-  - Libraries:
-    - Stripwell Methods
-    - Gradiant PCR
-  - OperationTypes:
-    - Run Gel
-    - Order Primer
+You can then either create new protocols or pull existing ones from your Aquarium instance.
+Let's first create a protocol using the `create` command
 
 ```bash
-pfish pull -d MyDirectoryName -c Cloning
+pfish create -c MyCategory -o MyProtocol
 ```
 
-will pull everything listed under cloning -- all operation types and libraries.
+which will create a protocol both in Aquarium and in the current directory.
+The local files will be in the directory `mycategory`:
 
 ```bash
-pfish pull -d MyDirectoryName -c Cloning -l "Stripwell Methods"
+.
+`-- mycategory
+    `-- operation_types
+        `-- myprotocol
+            |-- cost_model.rb
+            |-- definition.json
+            |-- documentation.rb
+            |-- precondition.rb
+            `-- protocol.rb
 ```
 
-will pull just the Stripwell Methods Library.
+Now make an initial git commit
 
 ```bash
-pfish push -d MyDirectoryName -c Cloning -o "Run Gel"
+git add mycategory
+git commit -m "Add new definition for MyProtocol"
 ```
 
-will pull just the Run Gel operation type.
+and then you can edit the files.
 
-## Pushing files to Aquarium
+> Pfish mangles names to be lowercase with spaces changed to underscores.
+> The original names are captured in the `definition.json` file and used when protocols and libraries are pushed.
+> You do need to use the Aquarium names for libraries that you use.
 
-_Note_: At the moment, an operation type or library must already exist in Aquarium for you to be able to push to it.
-If you are adding a new operation type or library, create a blank operation type or library with the name in Aquarium, pull it, add whatever you'd like, and then push.
+In the situation where you have protocol code already in Aquarium that you want to work with on disk, you can pull that code and add it to your git repository.
 
-You can push a category, including all operation types and libraries or push one library or one operation type at a time.
-Pushing an operation type will include all parts of that that type (protocol, test, cost model, documentation etc.)
-A lot of operation types are missing a test file; you may want to add one.
+For example, consider a `Cloning` category with the following structure
 
+- Libraries:
+  - Stripwell Methods
+  - Gradient PCR
+- Operation Types:
+  - Run Gel
+  - Order Primer
 
-For a category:
+You can pull this category by running
 
 ```bash
-pfish push -d <directory_name> -c <category_name> 
+pfish pull -c Cloning
 ```
 
-For a library:
+which will create the following directory structure
 
 ```bash
-pfish push -d <directory_name> -c <category_name> -l <library_name>
+cloning
+|-- libraries
+|   |-- stripwell_methods
+|   `-- gradient_pcr
+`-- operation_types
+    |-- run_gel
+    `-- order_primer
 ```
 
-For an operation type
+with each subdirectory containing the code for the components of each library or operation type.
+To add this code to the repository add the `cloning` directory and commit using git.
+
+When you change files and you can push the changes to Aquarium with the `push` command.
+For instance, if you changed the `Run Gel` protocol, you would run the command
 
 ```bash
-pfish push -d <directory_name> -c <category_name> -o <operation_type_name>
+pfish push -c Cloning -o "Run Gel"
 ```
 
-For a category
-You may need to refresh Aquarium to see the new version
+to push only that operation type.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ You must have Docker installed to run the script this way.
 Initially, pfish is configured to connect to a [local Aquarium instance](https://aquariumbio.github.io/aquarium-local/) using the default user login (`neptune`) and password (`aquarium`) at URL (`http://localhost/`).
 So, if you are using that Aquarium user, you don't need to do anything to start with.
 
-However, if you use a different login, you'll want to change the login and password for this local instance.
-To do this, use the command
+To use a different login with the local instance, run the command
 
 ```bash
 pfish configure add -l <user-login> -p <user-password>
@@ -41,8 +40,7 @@ pfish configure add -l <user-login> -p <user-password>
 
 with the new login name and password.
 
-This command is a shortened version of the full `configure add` command using default values for some of the arguments.
-The full `configure add` command is
+To add another login configuration, use the command
 
 ```bash
 pfish configure add -n <configuration-name> -l <user-login> -p <user-password> -u <instance-url>
@@ -50,40 +48,22 @@ pfish configure add -n <configuration-name> -l <user-login> -p <user-password> -
 
 where you specify the configuration-name, user-login, password and instance URL.
 A configuration name is simply a key to keep track of the login information for a particular Aquarium instance.
-Each of these arguments have defaults that correspond to the local configuration:
-
-- the default configuration name is `local`,
-- the login is `neptune`,
-- the password is `aquarium`, and
-- the URL is `http://localhost/`.
-
-So, the command for changing the local user from above
-
-```bash
-pfish configure add -l <user-login> -p <user-password>
-```
-
-uses the configuration name `local` and the URL `http://localhost/`.
+(Each of these arguments have defaults that correspond to the local configuration.)
 
 *Note*: The `configure add` command will overwrite an existing login configuration, as shown in this example.
 
 The most common use of `configure add` is to set up login configurations for different Aquarium instances.
 For instance, a user might have a `production` configuration in addition to the `local` configuration.
-In this case, with they would use the above command giving the configuration name `production` with their login details for the production instance:
+In this case, the `local` configuration is still used by default, but the `production` configuration can be specified when transferring protocols.
 
-```bash
-pfish configure add -n production -l <user-login> -p <user-password> -u <instance-url>
-```
-
-With these settings, the `local` configuration is still used by default, but the `production` configuration can be specified when transferring protocols.
-
-If needed, the default configuration can be set with the command
+To change the default configuration, use the command
 
 ```bash
 pfish configure set-default -n <config-name>
 ```
 
-which you might want to do if you do development on a staging instance rather than a local one.
+with the name of the login configuration that you want to be the default.
+You might want to do this if you do development on a staging instance rather than a local one.
 
 ## Commands
 

--- a/pfish-wrapper
+++ b/pfish-wrapper
@@ -26,11 +26,15 @@ check_cmd_in_path docker
 #check_cmd_in_path docker-machine
 #docker-machine active > /dev/null 2>&1 || error 2 "No active docker-machine VM found."
 
+# ensure a configuration directory
+CONFIG_DIR=$HOME/.pfish
+mkdir -p $CONFIG_DIR
+
 # Set up mounted volumes, environment, and run our containerized command
 exec docker run \
   --net=host \
   --interactive --tty --rm \
   --volume "$PWD":/wd \
-  --volume "$PWD/resources.py:/script/resources.py" \
+  --volume "$CONFIG_DIR:/script/config" \
   --workdir /wd \
   "aquariumbio/pfish:$VERSION" "$@"

--- a/pfish-wrapper
+++ b/pfish-wrapper
@@ -7,7 +7,7 @@
 # Inspired by https://spin.atomicobject.com/2015/11/30/command-line-tools-docker/
 
 PROGNAME="$(basename $0)"
-VERSION="0.0.1"
+VERSION="0.0.2"
 
 # Helper functions for guards
 error(){

--- a/pxfish/config.py
+++ b/pxfish/config.py
@@ -1,0 +1,59 @@
+import os
+import json
+
+from paths import makedirectory
+
+
+def config_file_path(path):
+    return os.path.join(path, 'config.json')
+
+
+def add_config(*, path, key, login, password, url):
+    """
+    Adds the given configuration information to the secrets file in the config
+    directory specified by the path.
+    """
+
+    makedirectory(path)
+    file_path = config_file_path(path)
+    config = get_config(file_path)
+
+    config['instances'][key] = {
+        'login': login,
+        'password': password,
+        'aquarium_url': url
+    }
+
+    with open(file_path, 'w') as file:
+        file.write(json.dumps(config, indent=2))
+
+
+def get_config(path):
+    """
+    Returns the dict from the config file at named path if file exists.
+    Otherwise, returns the default.
+    """
+    if os.path.isfile(path):
+        with open(path) as file:
+            return json.load(file)
+
+    return {
+        "default": "local",
+        "instances": {
+            "local": {
+                "login": "neptune",
+                "password": "aquarium",
+                "aquarium_url": "http://localhost/"
+            }
+        }
+    }
+
+
+def set_default_instance(path, *, name):
+    file_path = config_file_path(path)
+    config = get_config(file_path)
+
+    config["default"] = name
+
+    with open(file_path, 'w') as file:
+        file.write(json.dumps(config, indent=2))

--- a/pxfish/pyfish.py
+++ b/pxfish/pyfish.py
@@ -33,18 +33,13 @@ logging.basicConfig(level=logging.INFO)
 
 def main():
     args = get_arguments()
+    # call the function determined by the arguments
     args.func(args)
 
 
 def get_arguments():
     parser = argparse.ArgumentParser(
         description="Pull or Push files from/to Aquarium. Create new operation types")
-
-    parser.add_argument(
-        "-d", "--directory",
-        help="working directory for the command",
-        default=os.getcwd()
-    )
 
     # Create parsers for subcommands
     subparsers = parser.add_subparsers(title="subcommands")
@@ -106,6 +101,16 @@ def get_arguments():
 
 
 def add_code_arguments(parser, *, action):
+    parser.add_argument(
+        "-d", "--directory",
+        help="working directory for the command",
+        default=os.getcwd()
+    )
+    parser.add_argument(
+        "-n", "--name",
+        help="login configuration name",
+        default="local"
+    )
     parser.add_argument(
         "-c", "--category",
         help="category of the operation type or library",

--- a/pxfish/pyfish.py
+++ b/pxfish/pyfish.py
@@ -39,7 +39,7 @@ def main():
 
 def get_arguments():
     parser = argparse.ArgumentParser(
-        description="Pull or Push files from/to Aquarium. Create new operation types")
+        description="Create, push and pull Aquarium protocols")
 
     # Create parsers for subcommands
     subparsers = parser.add_subparsers(title="subcommands")

--- a/pxfish/pyfish.py
+++ b/pxfish/pyfish.py
@@ -6,6 +6,10 @@ identified in the resources.py file.
 import os
 import argparse
 import logging
+from config import (
+    add_config,
+    set_default_instance
+)
 from pull import (
     get_all,
     get_category,
@@ -22,102 +26,169 @@ from paths import (
     create_named_path,
     makedirectory
 )
-from resources import resources
-from pydent import AqSession
+from session import create_session
 
 logging.basicConfig(level=logging.INFO)
 
 
-def open_aquarium_session():
-    """
-    Starts Aquarium Session
-    """
-    aq = AqSession(
-        resources['aquarium']['login'],
-        resources['aquarium']['password'],
-        resources['aquarium']['url']
-    )
-    return aq
-
-
 def main():
+    args = get_arguments()
+    args.func(args)
+
+
+def get_arguments():
     parser = argparse.ArgumentParser(
         description="Pull or Push files from/to Aquarium. Create new operation types")
-    parser.add_argument(
-        "action",
-        choices=["push", "pull", "create"],
-        help="whether to push or pull Operation Type and/or Library files, or to create a new OperationType"
-    )
+
     parser.add_argument(
         "-d", "--directory",
-        help="directory for reading or writing files. Created if does not already exist",
+        help="working directory for the command",
         default=os.getcwd()
     )
-    parser.add_argument(
-        "-c", "--category",
-        help="category of the operation type or library"
-    )
 
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("-l", "--library", help="the library to pull")
-    group.add_argument(
-        "-o", "--operation_type",
-        help="the operation type to pull"
+    # Create parsers for subcommands
+    subparsers = parser.add_subparsers(title="subcommands")
+
+    parser_create = subparsers.add_parser("create")
+    add_code_arguments(parser_create, action="create")
+    parser_create.set_defaults(func=do_create)
+
+    parser_config = subparsers.add_parser("configure")
+    config_subparsers = parser_config.add_subparsers()
+    parser_add = config_subparsers.add_parser(
+        "add",
+        help="Add/update login configuration"
     )
+    parser_add.add_argument(
+        '-n', "--name",
+        help="the name to use for the aquarium instance",
+        default="local"
+    )
+    parser_add.add_argument(
+        "-l", "--login",
+        help="the login name for the aquarium instance",
+        default="neptune"
+    )
+    parser_add.add_argument(
+        "-p", "--password",
+        help="the password for the login",
+        default="aquarium"
+    )
+    parser_add.add_argument(
+        "-u", "--url",
+        help="the URL for the aquarim instance",
+        default="http://localhost/"
+    )
+    parser_add.set_defaults(func=do_config_add)
+
+    parser_default = config_subparsers.add_parser(
+        "set-default",
+        help="set default login configuration"
+    )
+    parser_default.add_argument(
+        '-n',
+        '--name',
+        help="the name of the default login configuration",
+        default="local"
+    )
+    parser_default.set_defaults(func=do_config_default)
+
+    parser_pull = subparsers.add_parser("pull")
+    add_code_arguments(parser_pull, action="pull")
+    parser_pull.set_defaults(func=do_pull)
+
+    parser_push = subparsers.add_parser("push")
+    add_code_arguments(parser_push, action="push")
+    parser_push.set_defaults(func=do_push)
 
     args = parser.parse_args()
+    return args
 
-    aq = open_aquarium_session()
 
+def add_code_arguments(parser, *, action):
+    parser.add_argument(
+        "-c", "--category",
+        help="category of the operation type or library",
+        required=(action == 'create' or action == 'push')
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-l", "--library",
+        help="the library to {}".format(action)
+    )
+    group.add_argument(
+        "-o", "--operation_type",
+        help="the operation type to {}".format(action)
+    )
+
+
+def config_path():
+    return os.path.normpath('/script/config')
+
+
+def do_config_add(args):
+    add_config(
+        path=config_path(),
+        key=args.name,
+        login=args.login,
+        password=args.password,
+        url=args.url
+    )
+
+
+def do_config_default(args):
+    set_default_instance(config_path(), name=args.name)
+
+
+def do_create(args):
+    aq = create_session(path=config_path())
     path = os.path.normpath(args.directory)
-    makedirectory(path)
 
-    if args.action == 'pull':
-        if not args.category:
-            if args.library:
-                logging.error("Category required to pull library")
-                return
-
-            if args.operation_type:
-                logging.error("Category required to pull operation type")
-                return
-
-            # no category, library or operation type
-            get_all(aq, path)
-            return
-
-        # have category, check for a library or operation type
-        if args.library:
-            get_library(aq, path, args.category, args.library)
-            return
-
-        if args.operation_type:
-            get_operation_type(aq, path, args.category, args.operation_type)
-            return
-
-        # get whole category
-        get_category(aq, path, args.category)
-        return
-
-    # action was not pull, should be push or create
-    if args.action != 'push' and args.action != 'create':
-        logging.warning("Expected an action")
-        return
-
-
-    # action is push or create
-    if not args.category:
-        logging.error('Category is required for push and create')
-        return
-
-    # have category, look for library or operation type
-    category_path = create_named_path(path, args.category)
-
-    if args.action == 'create' and args.operation_type:
+    if args.operation_type:
         create_new_operation_type(aq, path, args.category, args.operation_type)
         get_operation_type(aq, path, args.category, args.operation_type)
         return
 
+    if args.library:
+        # TODO: implement create library
+        pass
+
+
+def do_pull(args):
+    aq = create_session(path=config_path())
+    path = os.path.normpath(args.directory)
+
+    if not args.category:
+        if args.library:
+            logging.error("Category required to pull library")
+            return
+
+        if args.operation_type:
+            logging.error("Category required to pull operation type")
+            return
+
+        # no category, library or operation type
+        get_all(aq, path)
+        return
+
+    # have category, check for a library or operation type
+    if args.library:
+        get_library(aq, path, args.category, args.library)
+        return
+
+    if args.operation_type:
+        get_operation_type(aq, path, args.category, args.operation_type)
+        return
+
+    # get whole category
+    get_category(aq, path, args.category)
+
+
+def do_push(args):
+    aq = create_session(path=config_path())
+    path = os.path.normpath(args.directory)
+
+    category_path = create_named_path(path, args.category)
     if args.library:
         select_library(aq, category_path, args.library)
         return
@@ -125,7 +196,7 @@ def main():
     if args.operation_type:
         select_operation_type(aq, category_path, args.operation_type)
         return
-    
+
     select_category(aq, category_path)
 
 

--- a/pxfish/session.py
+++ b/pxfish/session.py
@@ -1,5 +1,3 @@
-import os
-
 from config import get_config, config_file_path
 from pydent import AqSession
 

--- a/pxfish/session.py
+++ b/pxfish/session.py
@@ -1,0 +1,39 @@
+import os
+
+from config import get_config, config_file_path
+from pydent import AqSession
+
+
+def create_session(*, path):
+    """
+    Create an aquarium session connected to the named Aquarium instance.
+
+    :param path: the config directory path
+    :type path: str
+    :return: new AqSession
+    """
+    file_path = config_file_path(path)
+    config = get_config(file_path)
+
+    name = config["default"]
+    if name not in config["instances"]:
+        raise BadInstanceError(name)
+
+    credentials = config["instances"][name]
+    session = AqSession(
+        credentials["login"],
+        credentials["password"],
+        credentials["aquarium_url"]
+    )
+
+    return session
+
+
+class BadInstanceError(Exception):
+    """
+    Exception raised when an instance name is given that does not occur in
+    the configuration file.
+    """
+
+    def __init__(self, name):
+        self.instance_name = name


### PR DESCRIPTION
Changes how the user configuration is handled and simplifies required options for commands:
1. the configuration (aka, secrets) are now stored in `~/.pfish/config.json` (in the user's home directory)
2. the user can add and modify configuration information via pfish commands rather than editing the file
3. pfish uses a default configuration that is initially the default aquarium-local user and password

Also, changes the implementation of command-line argument handling, and updates the readme.
