### PR TITLE
Remove ids in json files

### DIFF
--- a/pxfish/object_type.py
+++ b/pxfish/object_type.py
@@ -5,12 +5,7 @@ Functions for pulling Object Types in Aquarium.
 import json
 import logging
 import os
-import definition
 
-from definition import (
-    write_sample_types_json,
-    write_object_types_json,
-)
 from paths import (
     create_named_path,
     makedirectory,

--- a/pxfish/operation_type.py
+++ b/pxfish/operation_type.py
@@ -12,8 +12,6 @@ from code import (
     create_code_objects
 )
 from definition import (
-    write_sample_types_json,
-    write_object_types_json,
     write_definition_json
 )
 from paths import (

--- a/pxfish/sample_type.py
+++ b/pxfish/sample_type.py
@@ -7,10 +7,6 @@ import logging
 import os
 import definition
 
-from definition import (
-    write_sample_types_json,
-    write_object_types_json,
-)
 from paths import (
     create_named_path,
     makedirectory,

--- a/pxfish/sample_type.py
+++ b/pxfish/sample_type.py
@@ -32,7 +32,6 @@ def write_files(*, path, sample_type):
     makedirectory(path)
 
     sample_type_ser = {
-        "id": sample_type.id,
         "name": sample_type.name,
         "description": sample_type.description
     }


### PR DESCRIPTION
When I changed how I was pulling sample types, I left in some import statements. This takes them out.