### PR TITLE
Fix ruby test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Test Files
+TEST*/

--- a/pxfish/operation_type.py
+++ b/pxfish/operation_type.py
@@ -216,8 +216,7 @@ def run_test(*, session, path, category, name):
         category (String): Category operation type is found in
         name (String): name of the Operation Type to be tested
     """
-    logging.info('Sending request for %s', name)
-
+    logging.info('Sending request to test %s', name)
     push(session=session, path=path, test=True)
 
     retrieved_operation_type = get_operation_type(
@@ -225,7 +224,5 @@ def run_test(*, session, path, category, name):
 
     response = session._aqhttp.get(
         "test/run/{}".format(retrieved_operation_type.id))
-    #print(f"response is {response}")
 
-    parse_test_response(response)
-    # return
+    parse_test_response(response=response, file_path=path)

--- a/pxfish/operation_type.py
+++ b/pxfish/operation_type.py
@@ -19,7 +19,8 @@ from paths import (
     makedirectory
 )
 from protocol_test import (
-    parse_test_response
+    parse_test_response,
+    log_backtrace
 )
 
 
@@ -225,4 +226,7 @@ def run_test(*, session, path, category, name):
     response = session._aqhttp.get(
         "test/run/{}".format(retrieved_operation_type.id))
 
-    parse_test_response(response=response, file_path=path)
+    log_backtrace(response=response, file_path=path)
+    parse_test_response(response)
+    
+

--- a/pxfish/protocol_test.py
+++ b/pxfish/protocol_test.py
@@ -1,16 +1,22 @@
 """
 code for running operation type tests
 """
+import json
 import logging
+import os
 
-
-def parse_test_response(response):
+def parse_test_response(*, response, file_path):
     """
     Reports test results
+    Writes errors to screen and creates json file with backtrace
 
     Arguments:
         response (dict): response received after running test
     """
+    file_path = os.path.join(file_path, 'test_results.json')
+
+    with open(file_path, 'w') as file:
+        file.write(json.dumps(response, indent=2))
 
     if response["result"] == "error":
         if response["error_type"] == "error":
@@ -39,9 +45,4 @@ def parse_test_response(response):
     else:
         logging.info(
             "All tests passed")
-
-    return
-
-    # for entry in response.exception_backtrace:
-    #     pass
 

--- a/pxfish/protocol_test.py
+++ b/pxfish/protocol_test.py
@@ -5,19 +5,23 @@ import json
 import logging
 import os
 
-def parse_test_response(*, response, file_path):
-    """
-    Reports test results
-    Writes errors to screen and creates json file with backtrace
 
-    Arguments:
-        response (dict): response received after running test
-    """
+def log_backtrace(*, response, file_path):
+    """"""
     file_path = os.path.join(file_path, 'test_results.json')
 
     with open(file_path, 'w') as file:
         file.write(json.dumps(response, indent=2))
 
+
+def parse_test_response(response):
+    """
+    Reports test results
+    Writes errors to screen
+
+    Arguments:
+        response (dict): response received after running test
+    """
     if response["result"] == "error":
         if response["error_type"] == "error":
             logging.error(response["message"])


### PR DESCRIPTION
This fixes some issues with testing. Testing will now only push the protocol and the test file to aquarium, since there's no need to push the documentation etc.. Test Backtrace is now stored in a json file. 