### PR TITLE
Fix mistake in error messages so correct error is reported

### DIFF
--- a/pxfish/field_type.py
+++ b/pxfish/field_type.py
@@ -169,7 +169,7 @@ def types_valid(*, operation_type, definitions, session):
     if input_conflicts or output_conflicts:
         for conflict in input_conflicts:
             messages.append(f'There is a data conflict between the Aquarium Field Type definition of Output {conflict} and your local definition')
-        for conflict in missing_inputs:
+        for conflict in output_conflicts:
             messages.append(f'There is a data conflict between the Aquarium Field Type definition of Input {conflict} and your local definition')
 
     if messages:


### PR DESCRIPTION
I noticed while working on Sample Types that we were reporting the wrong Field Type error in one place. This fixes that error.