### PR TITLE
Add test timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ If data about an existing field type differs from what is in your instance, the 
 ### Test
 
 pfish can run ruby tests on Operation Types.
-Test results will be summarized on screen, with details saved to a file called test_results.json located within the folder for the Operation Type under test.
+Test results will be summarized on screen, with details saved to a file called `test_results.json` located within the folder for the Operation Type under test.
 
 The available test commands are:
 
@@ -211,6 +211,8 @@ The available test commands are:
    ```bash
    pfish test -c <category_name> -o <operation_type_name>
    ```
+
+   Tests will timeout at ten seconds, but a different timeout can be set using the `-t` parameter.
 
 2. Test Libraries: Not yet implemented
 

--- a/pxfish/category.py
+++ b/pxfish/category.py
@@ -92,7 +92,7 @@ def push(*, session, path):
                             directory_entry, path)
 
 
-def run_tests(*, session, path, name):
+def run_tests(*, session, path, name, timeout: int = None):
     """
     Runs tests for all library and operation type files in a specific category.
 
@@ -100,6 +100,7 @@ def run_tests(*, session, path, name):
         session (Session Object): Aquarium session object
         path (String): path to category
         name (String): name of the category to be tested
+        timeout (Int): time (seconds) to wait for test result
     """
     # TODO: another place to catch NotADirectoryError and other errors
     category_entries = os.listdir(path)
@@ -115,8 +116,12 @@ def run_tests(*, session, path, name):
                 logging.info('Testing Operation Type %s', filename)
                 entry_path = os.path.join(path, filename)
                 operation_type.run_test(
-                    session=session, path=entry_path,
-                    category=name, name=filename)
+                    session=session,
+                    path=entry_path,
+                    category=name,
+                    name=filename,
+                    timeout=timeout
+                )
         else:
             logging.warning(
                 'Unexpected directory entry %s in %s',

--- a/pxfish/instance.py
+++ b/pxfish/instance.py
@@ -82,7 +82,7 @@ def push(*, session, path):
         category.push(session=session, path=entry_path)
 
 
-def run_tests(*, session, path):
+def run_tests(*, session, path, timeout: int = None):
     """
     Runs tests on all operation types in directory
 
@@ -103,20 +103,27 @@ def run_tests(*, session, path):
                 session=session,
                 path=path,
                 category=definition.category,
-                name=definition.name
+                name=definition.name,
+                timeout=timeout
             )
         elif definition.is_library(def_dict):
             library.run_test(
                 session=session,
                 path=path,
                 category=definition.category,
-                name=definition.name
+                name=definition.name,
+                timeout=timeout
             )
         return
 
     if is_category(path):
         name = os.path.basename(path)
-        category.run_tests(session=session, path=path, name=name)
+        category.run_tests(
+            session=session,
+            path=path,
+            name=name,
+            timeout=timeout
+        )
         return
 
     entries = os.listdir(path)
@@ -130,4 +137,9 @@ def run_tests(*, session, path):
     for entry in dir_entries:
         entry_path = os.path.join(path, entry)
         if is_category(entry_path):
-            category.run_tests(session=session, path=entry_path, name=entry)
+            category.run_tests(
+                session=session,
+                path=entry_path,
+                name=entry,
+                timeout=timeout
+            )

--- a/pxfish/library.py
+++ b/pxfish/library.py
@@ -176,5 +176,5 @@ def push(*, session, path):
         session.utils.update_code(new_code)
 
 
-def run_test(*, session, path, category, name):
+def run_test(*, session, path, category, name, timeout: int = None):
     logging.error("Library tests are not currently available")

--- a/pxfish/operation_type.py
+++ b/pxfish/operation_type.py
@@ -87,6 +87,8 @@ def pull(*, session, path, category, name):
                 operation_type=retrieved_operation_type)
 
 # TODO Fix this so you're not passing an empty list as the default
+
+
 def write_files(*, session, path, operation_type, sample_types=[], object_types=[]):
     """
     Writes the files associated with the operation_type to the path.
@@ -219,8 +221,10 @@ def push(*, session, path, component_names=all_component_names()):
             return
 
         field_type.build(
-                definitions=definitions,
-                operation_type=parent_object[0], session=session)
+            definitions=definitions,
+            operation_type=parent_object[0],
+            session=session
+        )
 
     for name in component_names:
         read_file = code_component.read(path=path, name=name)
@@ -240,7 +244,7 @@ def push(*, session, path, component_names=all_component_names()):
         session.utils.update_code(new_code)
 
 
-def run_test(*, session, path, category, name):
+def run_test(*, session, path, category, name, timeout: int = None):
     """
     Run tests for specified operation type.
 
@@ -249,18 +253,22 @@ def run_test(*, session, path, category, name):
         path (String): Path to file
         category (String): Category operation type is found in
         name (String): name of the Operation Type to be tested
+        timeout (Int): time (seconds) to wait for test result
     """
     logging.info('Sending request to test %s', name)
     push(
-        session=session, path=path,
+        session=session,
+        path=path,
         component_names=test_component_names()
-        )
+    )
 
     retrieved_operation_type = get_operation_type(
         session=session, category=category, name=name)
 
     response = session._aqhttp.get(
-        "test/run/{}".format(retrieved_operation_type.id))
+        "test/run/{}".format(retrieved_operation_type.id),
+        timeout
+    )
 
     write_test_response(response=response, path=path)
     parse_test_response(response=response, file_path=path)

--- a/pxfish/pyfish.py
+++ b/pxfish/pyfish.py
@@ -104,6 +104,12 @@ def get_argument_parser():
 
     parser_test = subparsers.add_parser("test")
     add_code_arguments(parser_test, action="test")
+    parser_test.add_argument(
+        "-t", "--timeout",
+        help="timeout (seconds) for running test",
+        type=int,
+        default=None
+    )
     parser_test.set_defaults(func=do_test)
 
     return parser
@@ -275,7 +281,8 @@ def do_test(args):
                     category_path, args.operation_type,
                     subdirectory="libraries"),
                 category=args.category,
-                name=args.library
+                name=args.library,
+                timeout=args.timeout
             )
             return
 
@@ -286,12 +293,17 @@ def do_test(args):
                     category_path, args.operation_type,
                     subdirectory="operation_types"),
                 category=args.category,
-                name=args.operation_type
+                name=args.operation_type,
+                timeout=args.timeout
             )
             return
 
         category.run_tests(
-            session=session, path=category_path, name=args.category)
+            session=session, 
+            path=category_path, 
+            name=args.category,
+            timeout=args.timeout
+            )
         return
 
     if args.library or args.operation_type:
@@ -299,7 +311,7 @@ def do_test(args):
             "To test a single operation type or library, you must enter a category")
         return
 
-    instance.run_tests(session=session, path=path)
+    instance.run_tests(session=session, path=path, timeout=args.timeout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds the ability to set the timeout for response for running a test from a command-line. Pydent uses 10 seconds