### PR TITLE
Add push sample and object types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## -- 2021-02-24
+## -- 2021-03-30
+
+### Added
+- Functions to create Sample Types when creating a Field Type
+- Functions to create Object Types when creating a Field Type
+- Command Line flag to override conflict checks and overwrite instance data with local data
+
+### Changed
+- Added more detail to definition files for Sample Types and Field Types
+
+
+## -- 2021-02-24 -- [1.1.0] 
 
 ### Added
 -- Functions to create Field Types based on Definition Files

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ wget -vO- https://raw.githubusercontent.com/aquariumbio/pfish/master/pfish-insta
 
 This script will download the pfish wrapper script and install it in `~/bin`.
 
-Once the script is done, you'll need to [add `~/bin` to your PATH](https://opensource.com/article/17/6/set-path-linux).
-
+Once the script is done, you'll need to [add `~/bin` to your PATH](https://opensource.com/article/17/6/set-path-linux).  
 If you don't have `wget` installed, you can clone this repository and run `make install`.
 
 ## Updating
@@ -176,9 +175,20 @@ If there are Sample Types or Object Types connected to an Operation Types, data 
 
 Type information for all categories pulled will be in one folder to avoid duplicates.
 
-When pushing an operation type, any Field Types listed in your definition file that do not exist in your instance will be created. 
+When pushing an operation type, any Field Types listed in your definition file that do not exist in your instance will be created.
+
+If the associated Sample Types and Object Types exist in your instance, they will be used. If not, they will be created for you provided you have the information in your pFish directory.
+
+e.g. If you are adding a Sample Type named "my sample type", you need to have a `my_sample_type.json` file in the `sample_types` folder.
 
 If data about an existing field type differs from what is in your instance, the operation type will not be pushed.
+
+If you would like to override this setting and push the operation type anyway, replacing the data in your instance with your local data, you can set the force flag.
+
+
+   ```bash
+   pfish push -f -c <category-name> -o <operation-type-name>
+   ```
 
 ```bash
 .

--- a/pxfish/category.py
+++ b/pxfish/category.py
@@ -52,7 +52,7 @@ def pull(*, session, path, name):
         library.write_files(path=path, library=lib)
 
 
-def push(*, session, path):
+def push(*, session, path, force):
     """
     Finds all library and operation type files in a specific category.
 
@@ -85,7 +85,8 @@ def push(*, session, path):
                 operation_type.push(
                     session=session,
                     path=create_named_path(
-                        path, name, subdirectory='operation_types')
+                        path, name, subdirectory='operation_types'),
+                    force=force
                 )
         else:
             logging.warning('Unexpected directory entry %s in %s',

--- a/pxfish/definition.py
+++ b/pxfish/definition.py
@@ -45,6 +45,9 @@ def field_type_list(field_types):
             'part': field_type.part,
             'array': field_type.array,
             'routing': field_type.routing,
+            'ftype': field_type.ftype,
+            'choices': field_type.choices,
+            'required': field_type.required
             }
         if field_type.parent_class == "OperationType":
             ft_ser['allowable_field_types']: allowable_field_type_list(field_type.allowable_field_types)

--- a/pxfish/definition.py
+++ b/pxfish/definition.py
@@ -27,29 +27,27 @@ def name(obj: Dict) -> str:
     return obj['name']
 
 
-def field_type_list(field_types, role):
+def field_type_list(field_types):
     """
     Returns sublist of field types with the given role.
 
     Arguments:
       field_types (List): the list of field types
-      role (String): the role of field types to be returned (e.g. "input")
 
     Returns:
       list: the sublist of field_types that have the specified role
     """
     ft_list = []
     for field_type in field_types:
-        if field_type.role == role:
-            ft_ser = {
-                'name': field_type.name,
-                'part': field_type.part,
-                'array': field_type.array,
-                'routing': field_type.routing,
-                'allowable_field_types':
-                    allowable_field_type_list(field_type.allowable_field_types)
-                }
-            ft_list.append(ft_ser)
+        ft_ser = {
+            'name': field_type.name,
+            'part': field_type.part,
+            'array': field_type.array,
+            'routing': field_type.routing,
+            'allowable_field_types':
+                allowable_field_type_list(field_type.allowable_field_types)
+            }
+        ft_list.append(ft_ser)
     return ft_list
 
 
@@ -78,8 +76,12 @@ def write_definition_json(file_path, operation_type):
     ot_ser['name'] = operation_type.name
     ot_ser['parent_class'] = 'OperationType'
     ot_ser['category'] = operation_type.category
-    ot_ser['inputs'] = field_type_list(operation_type.field_types, 'input')
-    ot_ser['outputs'] = field_type_list(operation_type.field_types, 'output')
+    ot_ser['inputs'] = field_type_list(
+            [ft for ft in operation_type.field_types if ft.role == 'input']
+            )
+    ot_ser['outputs'] = field_type_list(
+            [ft for ft in operation_type.field_types if ft.role == 'output']
+            )
     ot_ser['on_the_fly'] = operation_type.on_the_fly
     ot_ser['user_id'] = operation_type.protocol.user_id
 

--- a/pxfish/definition.py
+++ b/pxfish/definition.py
@@ -37,6 +37,7 @@ def field_type_list(field_types):
     Returns:
       list: the sublist of field_types that have the specified role
     """
+    #TODO: Distinuish Parameters from other inputs/outputs
     ft_list = []
     for field_type in field_types:
         ft_ser = {
@@ -44,9 +45,9 @@ def field_type_list(field_types):
             'part': field_type.part,
             'array': field_type.array,
             'routing': field_type.routing,
-            'allowable_field_types':
-                allowable_field_type_list(field_type.allowable_field_types)
             }
+        if field_type.parent_class == "OperationType":
+            ft_ser['allowable_field_types']: allowable_field_type_list(field_type.allowable_field_types)
         ft_list.append(ft_ser)
     return ft_list
 

--- a/pxfish/definition.py
+++ b/pxfish/definition.py
@@ -37,7 +37,7 @@ def field_type_list(field_types):
     Returns:
       list: the sublist of field_types that have the specified role
     """
-    #TODO: Distinuish Parameters from other inputs/outputs
+    #TODO: Distinguish Parameters from other inputs/outputs
     ft_list = []
     for field_type in field_types:
         ft_ser = {
@@ -50,21 +50,32 @@ def field_type_list(field_types):
             'required': field_type.required
             }
         if field_type.parent_class == "OperationType":
-            ft_ser['allowable_field_types']: allowable_field_type_list(field_type.allowable_field_types)
+            allowable_field_types = allowable_field_type_list(field_type.allowable_field_types)
+            ft_ser['allowable_field_types'] = allowable_field_types
+
         ft_list.append(ft_ser)
     return ft_list
 
 
 def allowable_field_type_list(allowable_field_types):
+    """
+    Arguments:
+      allowable_field_types (List): list of AFTs associated with Field Type
 
+    Returns:
+      object_and_sample_types (List): list of object and sample types associated with AFT
+    """
     object_and_sample_types = []
     for aft in allowable_field_types:
         ser = {}
         if aft.sample_type:
             ser['sample_type'] = aft.sample_type.name
+
         if aft.object_type:
             ser['object_type'] = aft.object_type.name
+
         object_and_sample_types.append(ser)
+
     return object_and_sample_types
 
 

--- a/pxfish/field_type.py
+++ b/pxfish/field_type.py
@@ -16,7 +16,7 @@ def add_field_type(*, operation_type, definition, role, path, session):
         operation_type (Operation Type): parent object
         definition (Dictionary): data about field types
         role (String): input or output
-        path
+        path (String): path to operation type
         session (Session Object): Aquarium session object
     """
     query = {
@@ -35,7 +35,6 @@ def add_field_type(*, operation_type, definition, role, path, session):
             if sample_obj_pair not in extant_afts:
                 new_aft = add_aft(aft_def=sample_obj_pair, session=session, path=path)
                 current_afts.append(new_aft)
-                #field_type.allowable_field_types.append(new_aft) #this is just adding to the list
         field_type.allowable_field_types = current_afts
     else:
         field_type = session.FieldType.new()
@@ -51,7 +50,7 @@ def add_field_type(*, operation_type, definition, role, path, session):
                 aft_def=aft, session=session, path=path
                 )
             for aft in definition['allowable_field_types']]
-# At this point when starting from scratch, afts have been created
+
     return field_type
 
 
@@ -62,7 +61,7 @@ def build(*, operation_type, definitions, path, session):
     Arguments:
         operation_type (Operation Type): parent object
         definitions (Dictionary): data about field types
-        path
+        path (String): path to Operation Type
         session (Session Object): Aquarium session object
     """
 
@@ -89,7 +88,7 @@ def build(*, operation_type, definitions, path, session):
                 session=session)
         )
     operation_type.field_types = field_types
-    # This is where the magic happens!
+
     session.utils.update_operation_type(operation_type)
 
 
@@ -104,7 +103,7 @@ def add_aft(*, aft_def, session, path):
     if sample_type.exists(
             session=session,
             sample_type=aft_def['sample_type']
-            ):
+        ):
         sampl_type = session.SampleType.new()
         sampl_type.name = aft_def['sample_type']
     else:
@@ -176,9 +175,8 @@ def check_for_conflicts(*, field_types, definitions, force):
             if not force and not equivalent(
                     field_type=type_map[name],
                     definition=definition
-                    ):
-
-                    conflicts[name] = definition
+            ):
+                conflicts[name] = definition
         else:
             local_diff[name] = definition
 
@@ -214,27 +212,35 @@ def types_valid(*, operation_type, definitions, force, session):
 
     if missing_inputs or missing_outputs:
         for conflict in missing_inputs:
-            messages.append(f'Aquarium Field Type Input, {conflict}, \
-            is not in your definition file.\n')
+            messages.append(
+                (f'Aquarium Field Type Input, "{conflict}", '
+                 'is not in your definition file.\n')
+            )
         for conflict in missing_outputs:
-            messages.append(f'Aquarium Field Type Output, {conflict}, \
-            is not in your definition file.\n')
+            messages.append((f'Aquarium Field Type Output, "{conflict}",'
+                             'is not in your definition file.\n'))
 
     if input_conflicts or output_conflicts:
         for conflict in input_conflicts:
-            messages.append(f'There is a data conflict between the Aquarium Field Type \
-        Definition of Input, {conflict}, and your local definition\n')
+            messages.append(
+                ('There is a data conflict between the Aquarium Field Type '
+                 f'Definition of Input, "{conflict}", and your local definition.\n'))
         for conflict in output_conflicts:
-            messages.append(f'There is a data conflict between the Aquarium Field Type \
-        Definition of Output, {conflict}, and your local definition\n')
+            messages.append(
+                ('There is a data conflict between the Aquarium Field Type '
+                 f'Definition of Output, "{conflict}", and your local definition.\n')
+            )
 #TODO This will let you override everything -- is that what I want it to do?
     if messages:
         messages = ' '.join(messages)
         logging.warning(
-            'The Following Field Type Conflict(s) exist: \n %s. \
-        Operation Type %s will not be pushed. To override this and replace instance data with data from your definition file, run push again with the force flag (-f, --force) set.',
-        messages, operation_type.name
-            )
+            'The Following Field Type Conflict(s) exist: \n %s', messages)
+        logging.warning(
+            'Operation Type "%s" will not be pushed.', operation_type.name)
+        logging.info(
+            'To override this and replace instance data with data from your definition file,\n \
+            run push again with the force flag (-f, --force) set.')
+        #logging.warning(
         return False
 
     return True

--- a/pxfish/field_type.py
+++ b/pxfish/field_type.py
@@ -1,6 +1,5 @@
 """Functions for Creating Field Types and Allowable Field Types"""
 
-
 import logging
 from definition import field_type_list
 
@@ -35,7 +34,6 @@ def add_field_type(*, operation_type, definition, role, session):
         ft.allowable_field_types = add_aft(
             session=session, definition=definition
         )
-
     return ft
 
 
@@ -111,12 +109,11 @@ def check_for_conflicts(*, field_types, definitions):
     Arguments:
         field_types (List): Field Types retrieved from Aquarium
         defintions (Dictionary): data about field types stored in defintion file
-    returns Dictionary containing:
+    returns:
         conflicts (Dictionary): Field Types in both places with differing data
         local_diff (Dictionary): Field Types in definition file Only
         aquarium_diff_names (Dictionary): Field Types in Aquarium Only
     """
-
     type_map = {field_type.name: field_type for field_type in field_types}
     local_diff = dict()
     match_names = set()
@@ -134,8 +131,6 @@ def check_for_conflicts(*, field_types, definitions):
     aquarium_diff_names = set(type_map.keys()).difference(match_names)
 
     return (aquarium_diff_names, local_diff,  conflicts)
-    #return {'aquarium_diff_names': aquarium_diff_names,
-            #'local_diff': local_diff, 'conflicts': conflicts}
 
 
 def types_valid(*, operation_type, definitions, session):
@@ -162,20 +157,18 @@ def types_valid(*, operation_type, definitions, session):
     messages = []
     if missing_inputs or missing_outputs:
         for conflict in missing_inputs:
-            messages.append(f'Aquarium Field Type Input {conflict} is not in your definition file.')
+            messages.append(f'Aquarium Field Type Input, {conflict}, is not in your definition file.\n')
         for conflict in missing_outputs:
-            messages.append(f'Aquarium Field Type Output {conflict} is not in your definition file.')
-
+            messages.append(f'Aquarium Field Type Output, {conflict}, is not in your definition file.\n')
     if input_conflicts or output_conflicts:
         for conflict in input_conflicts:
-            messages.append(f'There is a data conflict between the Aquarium Field Type definition of Output {conflict} and your local definition')
-        for conflict in missing_inputs:
-            messages.append(f'There is a data conflict between the Aquarium Field Type definition of Input {conflict} and your local definition')
-
+            messages.append(f'There is a data conflict between the Aquarium Field Type Definition of Input, {conflict}, and your local definition\n')
+        for conflict in output_conflicts:
+            messages.append(f'There is a data conflict between the Aquarium Field Type Definition of Output, {conflict}, and your local definition\n')
     if messages:
         messages = ' '.join(messages)
         logging.warning(
-                'The Following Field Type Conflict(s) exist: %s. Operation Type %s will not be pushed',
+                'The Following Field Type Conflict(s) exist:\n %s. Operation Type %s will not be pushed\n',
                     messages, operation_type.name
                     )
         return False

--- a/pxfish/field_type.py
+++ b/pxfish/field_type.py
@@ -23,7 +23,6 @@ def add_field_type(*, operation_type, definition, role, path, session):
         'role': role
     }
     field_type = session.FieldType.where(query)
-
     if field_type:
         ft = field_type[0]
     else:
@@ -33,7 +32,7 @@ def add_field_type(*, operation_type, definition, role, path, session):
         ft.part = definition['part']
         ft.routing = definition['routing']
         ft.name = query['name']
-        ft.ftype = 'sample'
+        ft.ftype = definition['ftype']
         ft.allowable_field_types = add_aft(
             definition=definition, path=path, session=session
         )
@@ -50,7 +49,6 @@ def build(*, operation_type, definitions, path, session):
         session (Session Object): Aquarium session object
     """
     field_types = []
-
     for field_type_definition in definitions['inputs']:
         field_types.append(add_field_type(
             operation_type=operation_type,
@@ -79,7 +77,7 @@ def add_aft(*, session, definition, path):
         definition (Dictionary): Data about Sample and Object types
     """
     afts = []
-    for aft in definition['allowable_field_types']: # an array of dictionaries
+    for aft in definition['allowable_field_types']:
         if sample_type.exists(
                     session=session,
                     sample_type=aft['sample_type']
@@ -92,11 +90,10 @@ def add_aft(*, session, definition, path):
                     sample_type=aft['sample_type'],
                     path=path
                         )
-
-            #if object_type.exists(session, associated_type['object_type']):
-            #    ot = session.ObjectType.new()
-            #else:
-            #    ot = object_type.create(session, associated_type['object_type'])
+        #if object_type.exists(session, associated_type['object_type']):
+        #    ot = session.ObjectType.new()
+        #else:
+        #    ot = object_type.create(session, associated_type['object_type'])
 
         # afts.append({'sample_type': st, 'object_type': ot})
 
@@ -112,7 +109,7 @@ def equivalent(*, field_type, definition):
     Returns True if equivalent, False otherwise.
     """
     field_type_data = field_type_list(
-            field_types=[field_type], role=field_type.role)
+            field_types=[field_type])
     for k, v in definition.items():
         if field_type_data[0][k] != v:
             return False
@@ -139,6 +136,7 @@ def check_for_conflicts(*, field_types, definitions):
         name = definition['name']
         if name in type_map:
             match_names.add(name)
+            # TODO: Fix equivelance check so it will let you add ST and OT to existing FTs
             if not equivalent(field_type=type_map[name], definition=definition):
                 conflicts[name] = definition
         else:

--- a/pxfish/field_type.py
+++ b/pxfish/field_type.py
@@ -28,14 +28,14 @@ def add_field_type(*, operation_type, definition, role, path, session):
 
     if retrieved_field_type:
         field_type = retrieved_field_type[0]
-        current_afts = field_type.allowable_field_types
+        all_afts = field_type.allowable_field_types
         extant_afts = field_type_list(field_types=[field_type])[0]['allowable_field_types']
 
         for sample_obj_pair in definition['allowable_field_types']:
             if sample_obj_pair not in extant_afts:
                 new_aft = add_aft(aft_def=sample_obj_pair, session=session, path=path)
-                current_afts.append(new_aft)
-        field_type.allowable_field_types = current_afts
+                all_afts.append(new_aft)
+        field_type.allowable_field_types = all_afts
     else:
         field_type = session.FieldType.new()
         field_type.role = role
@@ -230,7 +230,6 @@ def types_valid(*, operation_type, definitions, force, session):
                 ('There is a data conflict between the Aquarium Field Type '
                  f'Definition of Output, "{conflict}", and your local definition.\n')
             )
-#TODO This will let you override everything -- is that what I want it to do?
     if messages:
         messages = ' '.join(messages)
         logging.warning(
@@ -240,7 +239,6 @@ def types_valid(*, operation_type, definitions, force, session):
         logging.info(
             'To override this and replace instance data with data from your definition file,\n \
             run push again with the force flag (-f, --force) set.')
-        #logging.warning(
         return False
 
     return True

--- a/pxfish/field_type.py
+++ b/pxfish/field_type.py
@@ -172,21 +172,26 @@ def types_valid(*, operation_type, definitions, session):
     messages = []
     if missing_inputs or missing_outputs:
         for conflict in missing_inputs:
-            messages.append(f'Aquarium Field Type Input, {conflict}, is not in your definition file.\n')
+            messages.append(f'Aquarium Field Type Input, {conflict}, \
+            is not in your definition file.\n')
         for conflict in missing_outputs:
-            messages.append(f'Aquarium Field Type Output, {conflict}, is not in your definition file.\n')
+            messages.append(f'Aquarium Field Type Output, {conflict}, \
+            is not in your definition file.\n')
     if input_conflicts or output_conflicts:
         for conflict in input_conflicts:
-            messages.append(f'There is a data conflict between the Aquarium Field Type Definition of Input, {conflict}, and your local definition\n')
+            messages.append(f'There is a data conflict between the Aquarium Field Type \
+            Definition of Input, {conflict}, and your local definition\n')
         for conflict in output_conflicts:
-            messages.append(f'There is a data conflict between the Aquarium Field Type Definition of Output, {conflict}, and your local definition\n')
+            messages.append(f'There is a data conflict between the Aquarium Field Type \
+            Definition of Output, {conflict}, and your local definition\n')
 
     if messages:
         messages = ' '.join(messages)
         logging.warning(
-                'The Following Field Type Conflict(s) exist:\n %s. Operation Type %s will not be pushed\n',
-                    messages, operation_type.name
-                    )
+            'The Following Field Type Conflict(s) exist:\n %s. \
+            Operation Type %s will not be pushed\n',
+            messages, operation_type.name
+            )
         return False
 
     return True

--- a/pxfish/object_type.py
+++ b/pxfish/object_type.py
@@ -32,7 +32,25 @@ def create(*, session, object_type, path):
 
     data_dict = read(path=path, object_type=object_type)
     # TODO: try except for File not Found Error
-    obj_type = session.ObjectType.new(name=data_dict['name'], description=data_dict['description'])
+    obj_type = session.ObjectType.new(
+        name=data_dict['name'],
+        description=data_dict['description'],
+        min=data_dict['min'],
+        max=data_dict['max'],
+        handler=data_dict['handler'],
+        safety=data_dict['safety'],
+        clean_up=data_dict['clean up'],
+        data=data_dict['data'],
+        vendor=data_dict['vendor'],
+        unit=data_dict['unit'],
+        cost=data_dict['cost'],
+        release_method=data_dict['release method'],
+        release_description=data_dict['release description'],
+        image=data_dict['image'],
+        prefix=data_dict['prefix'],
+        rows=data_dict['rows'],
+        columns=data_dict['columns']
+        )
     obj_type.save()
     return obj_type
 

--- a/pxfish/object_type.py
+++ b/pxfish/object_type.py
@@ -29,8 +29,11 @@ def create(*, session, object_type, path):
     """
     path = pathlib.PurePath(path).parts[0]
     path = create_named_path(path, 'object_types')
-
-    data_dict = read(path=path, object_type=object_type)
+    breakpoint()
+    try:
+        data_dict = read(path=path, object_type=object_type)
+    except FileNotFoundError:
+        return
     # TODO: try except for File not Found Error
     obj_type = session.ObjectType.new(
         name=data_dict['name'],
@@ -64,10 +67,12 @@ def read(*, path, object_type):
 
     try:
         with open(file_path) as file:
+            breakpoint()
             data_dict = json.load(file)
     except FileNotFoundError as error:
         logging.warning(
             'Error %s reading expected code file %s', error, 'definition.json')
+        raise FileNotFoundError
     return data_dict
 
 def write_files(*, path, object_type):

--- a/pxfish/operation_type.py
+++ b/pxfish/operation_type.py
@@ -192,6 +192,7 @@ def push(*, session, path, component_names=all_component_names()):
     Arguments:
         session (Session Object): Aquarium session object
         path (String): Directory where files are to be found
+        component_names (List): Files to include as part of OT
     """
     if not is_operation_type(path):
         logging.warning('No Operation Type at %s', path)
@@ -207,12 +208,14 @@ def push(*, session, path, component_names=all_component_names()):
 
     parent_object = session.OperationType.where(query)
 
+    # TODO: Shouldn't finish create if there are FT conflicts
     if not parent_object:
         create(session=session, path=path, category=definitions['category'],
                name=definitions['name'], default_text=False)
         parent_object = session.OperationType.where(query)
 
     if definitions['inputs'] or definitions['outputs']:
+        # Check for Valid Field Types
         if not field_type.types_valid(
                 definitions=definitions,
                 operation_type=parent_object[0], session=session):
@@ -220,8 +223,9 @@ def push(*, session, path, component_names=all_component_names()):
 
         field_type.build(
                 definitions=definitions,
-                operation_type=parent_object[0], session=session)
+                operation_type=parent_object[0], path=path, session=session)
 
+    # TODO: Split out code creation to a seperate function
     for name in component_names:
         read_file = code_component.read(path=path, name=name)
         if read_file is None:

--- a/pxfish/operation_type.py
+++ b/pxfish/operation_type.py
@@ -192,6 +192,7 @@ def push(*, session, path, force, component_names=all_component_names()):
     Arguments:
         session (Session Object): Aquarium session object
         path (String): Directory where files are to be found
+        force (Boolean): If set, overrides conflict checks for Field Types
         component_names (List): Files to include as part of OT
     """
     if not is_operation_type(path):
@@ -215,17 +216,16 @@ def push(*, session, path, force, component_names=all_component_names()):
         parent_object = session.OperationType.where(query)
 
     if definitions['inputs'] or definitions['outputs']:
-        # Check for Valid Field Types
         if not field_type.types_valid(
                 definitions=definitions,
                 operation_type=parent_object[0],
                 force=force,
                 session=session):
             return
-
+        
         field_type.build(
-                definitions=definitions,
-                operation_type=parent_object[0], path=path, session=session)
+            definitions=definitions,
+            operation_type=parent_object[0], path=path, session=session)
 
     # TODO: Split out code creation to a seperate function
     for name in component_names:
@@ -258,7 +258,7 @@ def run_test(*, session, path, category, name):
     """
     logging.info('Sending request to test %s', name)
     push(
-        session=session, path=path,
+        session=session, path=path, force=False,
         component_names=test_component_names()
         )
 

--- a/pxfish/operation_type.py
+++ b/pxfish/operation_type.py
@@ -185,7 +185,7 @@ def create(*, session, path, category, name, default_text=True, field_types=[]):
     session.utils.create_operation_type(new_operation_type)
 
 
-def push(*, session, path, component_names=all_component_names()):
+def push(*, session, path, force, component_names=all_component_names()):
     """
     Pushes files to the Aquarium instance
 
@@ -218,7 +218,9 @@ def push(*, session, path, component_names=all_component_names()):
         # Check for Valid Field Types
         if not field_type.types_valid(
                 definitions=definitions,
-                operation_type=parent_object[0], session=session):
+                operation_type=parent_object[0],
+                force=force,
+                session=session):
             return
 
         field_type.build(

--- a/pxfish/pyfish.py
+++ b/pxfish/pyfish.py
@@ -103,7 +103,8 @@ def get_argument_parser():
     parser_push.add_argument(
         '-f', '--force',
         help='overwrite existing instance field types with data from definition file',
-        default=False
+        default=False,
+        action="store_true"
         )
     parser_push.set_defaults(func=do_push)
 

--- a/pxfish/pyfish.py
+++ b/pxfish/pyfish.py
@@ -88,8 +88,8 @@ def get_argument_parser():
     parser_default.set_defaults(func=do_config_default)
 
     parser_show = config_subparsers.add_parser(
-        "show",
-        help="show all configurations"
+        'show',
+        help='show all configurations'
     )
 
     parser_show.set_defaults(func=do_config_show)
@@ -100,6 +100,11 @@ def get_argument_parser():
 
     parser_push = subparsers.add_parser("push")
     add_code_arguments(parser_push, action="push")
+    parser_push.add_argument(
+        '-f', '--force',
+        help='overwrite existing instance field types with data from definition file',
+        default=False
+        )
     parser_push.set_defaults(func=do_push)
 
     parser_test = subparsers.add_parser("test")
@@ -237,7 +242,8 @@ def do_push(args):
             library.push(
                 session=session,
                 path=create_named_path(
-                    category_path, args.library, subdirectory='libraries')
+                    category_path, args.library, subdirectory='libraries'),
+                force=args.force
             )
             return
 
@@ -246,11 +252,12 @@ def do_push(args):
                 session=session,
                 path=create_named_path(
                     category_path, args.operation_type,
-                    subdirectory='operation_types')
+                    subdirectory='operation_types'),
+                force=args.force
             )
             return
 
-        category.push(session=session, path=category_path)
+        category.push(session=session, path=category_path, force=args.force)
         return
 
     if args.library or args.operation_type:

--- a/pxfish/sample_type.py
+++ b/pxfish/sample_type.py
@@ -13,6 +13,29 @@ from paths import (
     simplename
 )
 
+
+def exists(*, session, smpl_type):
+    """
+    Checks whether a Sample Type named in definition exists in Aquarium
+    """
+    # TODO: we are not currently storing the description in the definition file
+    sample_type = session.SampleType.where({'name': smpl_type})
+    
+    if sample_type:
+        return True
+    else:
+        return False
+
+
+def create(*, session, smpl_type):
+    """
+    Creates a new Sample Type in Aquarium
+    """
+    s = session.SampleType(name=smpl_type, description="fake")
+    s.save()
+    return s
+
+
 def write_files(*, path, sample_type):
     """
     Writes the files associated with the sample_type to the path.
@@ -28,8 +51,8 @@ def write_files(*, path, sample_type):
     makedirectory(path)
 
     sample_type_ser = {
-        "name": sample_type.name,
-        "description": sample_type.description
+        'name': sample_type.name,
+        'description': sample_type.description
     }
 
     name = simplename(sample_type_ser['name'])

--- a/pxfish/sample_type.py
+++ b/pxfish/sample_type.py
@@ -14,27 +14,48 @@ from paths import (
 )
 
 
-def exists(*, session, smpl_type):
+def exists(*, session, sample_type):
     """
     Checks whether a Sample Type named in definition exists in Aquarium
     """
     # TODO: we are not currently storing the description in the definition file
-    sample_type = session.SampleType.where({'name': smpl_type})
-    
-    if sample_type:
-        return True
-    else:
-        return False
+    sample_type = session.SampleType.where({'name': sample_type})
+
+    return bool(sample_type)
 
 
-def create(*, session, smpl_type):
+def create(*, session, sample_type, path):
     """
     Creates a new Sample Type in Aquarium
     """
-    s = session.SampleType(name=smpl_type, description="fake")
+    data_dict = read(path=path, sample_type=sample_type)
+    # use data_dict to create type
+    query = {
+            'name':  data_dict['name'],
+            'description': data_dict['description']
+            }
+
+    s = session.SampleType(query)
     s.save()
     return s
 
+
+def read(*, path, sample_type):
+    # path will be directory/category/operation_types/ot
+    # needs to be directory/sample_types/ot.json
+    # needs to read file in object types folder
+    # needs path and file name (sample type name simplified)
+    # But, Sample Names are Case Sensitive, so our simplify method can create conflicts
+    # path should be Dir/sample_types/file.json
+    file_path = os.path.join(path, 'definition.json')
+    try:
+        with open(file_path) as file:
+            data_dict = json.load(file)
+    except FileNotFoundError as error:
+        logging.warning(
+            'Error %s reading expected code file %s', error, 'definition.json')
+    return data_dict
+    
 
 def write_files(*, path, sample_type):
     """

--- a/pxfish/sample_type.py
+++ b/pxfish/sample_type.py
@@ -18,7 +18,6 @@ def exists(*, session, sample_type):
     """
     # TODO: we are not currently storing the description in the definition file
     sample_type = session.SampleType.where({'name': sample_type})
-
     return bool(sample_type)
 
 
@@ -26,26 +25,23 @@ def create(*, session, sample_type, path):
     """
     Creates a new Sample Type in Aquarium
     """
+    # TODO: Make this WAY less messy
+    path = os.path.split( os.path.split(path)[0])[0]
+    path = os.path.split(path)[0]
+    path = create_named_path(path, 'sample_types')
+    
     data_dict = read(path=path, sample_type=sample_type)
-    # use data_dict to create type
-    query = {
-            'name':  data_dict['name'],
-            'description': data_dict['description']
-            }
 
-    s = session.SampleType(query)
+    s = session.SampleType.new(name=data_dict['name'], description=data_dict['description'])
     s.save()
     return s
 
 
 def read(*, path, sample_type):
-    # path will be directory/category/operation_types/ot
-    # needs to be directory/sample_types/ot.json
-    # needs to read file in object types folder
-    # needs path and file name (sample type name simplified)
-    # But, Sample Names are Case Sensitive, so our simplify method can create conflicts
-    # path should be Dir/sample_types/file.json
-    file_path = os.path.join(path, 'definition.json')
+
+    sample_type = simplename(sample_type) + ".json"
+    file_path = os.path.join(path, sample_type)
+    
     try:
         with open(file_path) as file:
             data_dict = json.load(file)
@@ -53,7 +49,7 @@ def read(*, path, sample_type):
         logging.warning(
             'Error %s reading expected code file %s', error, 'definition.json')
     return data_dict
- 
+
 
 def write_files(*, path, sample_type):
     """

--- a/pxfish/sample_type.py
+++ b/pxfish/sample_type.py
@@ -1,6 +1,4 @@
-"""
-Functions for pulling Sample Types in Aquarium.
-"""
+"""Functions for pulling Sample Types in Aquarium."""
 
 import json
 import logging
@@ -55,7 +53,7 @@ def read(*, path, sample_type):
         logging.warning(
             'Error %s reading expected code file %s', error, 'definition.json')
     return data_dict
-    
+ 
 
 def write_files(*, path, sample_type):
     """
@@ -73,7 +71,8 @@ def write_files(*, path, sample_type):
 
     sample_type_ser = {
         'name': sample_type.name,
-        'description': sample_type.description
+        'description': sample_type.description,
+        'field_types': definition.field_type_list(sample_type.field_types)
     }
 
     name = simplename(sample_type_ser['name'])

--- a/pxfish/sample_type.py
+++ b/pxfish/sample_type.py
@@ -1,6 +1,7 @@
 """Functions for pulling Sample Types in Aquarium."""
 
 import json
+import pathlib
 import logging
 import os
 import definition
@@ -25,23 +26,23 @@ def create(*, session, sample_type, path):
     """
     Creates a new Sample Type in Aquarium
     """
-    # TODO: Make this WAY less messy
-    path = os.path.split( os.path.split(path)[0])[0]
-    path = os.path.split(path)[0]
+    path = pathlib.PurePath(path).parts[0]
     path = create_named_path(path, 'sample_types')
-    
-    data_dict = read(path=path, sample_type=sample_type)
 
-    s = session.SampleType.new(name=data_dict['name'], description=data_dict['description'])
-    s.save()
-    return s
+    data_dict = read(path=path, sample_type=sample_type)
+    # TODO: try except for File not Found Error
+    smpl_type = session.SampleType.new(name=data_dict['name'], description=data_dict['description'])
+    smpl_type.save()
+    return smpl_type
 
 
 def read(*, path, sample_type):
-
+    """
+    Reads the json file for the indicated sample type
+    """
     sample_type = simplename(sample_type) + ".json"
     file_path = os.path.join(path, sample_type)
-    
+
     try:
         with open(file_path) as file:
             data_dict = json.load(file)

--- a/pxfish/sample_type.py
+++ b/pxfish/sample_type.py
@@ -29,8 +29,10 @@ def create(*, session, sample_type, path):
     path = pathlib.PurePath(path).parts[0]
     path = create_named_path(path, 'sample_types')
 
-    data_dict = read(path=path, sample_type=sample_type)
-    # TODO: try except for File not Found Error
+    try:
+        data_dict = read(path=path, sample_type=sample_type)
+    except FileNotFoundError:
+        return
     smpl_type = session.SampleType.new(name=data_dict['name'], description=data_dict['description'])
     smpl_type.save()
     return smpl_type
@@ -49,6 +51,7 @@ def read(*, path, sample_type):
     except FileNotFoundError as error:
         logging.warning(
             'Error %s reading expected code file %s', error, 'definition.json')
+        raise FileNotFoundError
     return data_dict
 
 


### PR DESCRIPTION
This update: 

(1) Adds a feature to create any needed sample and object types when creating field types.
(2) Adds a force flag to override conflicts between field type data in definition files and versions saved in an instance. 
(3) Fixes issue with adding additional AFTs to an existing FT
(4) Updates Pull function to save more information about Sample Types. 

