### PR TITLE
Add workaround for old definition files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## -- 2021-03-30
+## -- 2021-04-12 -- [1.2.0]
 
 ### Added
 - Functions to create Sample Types when creating a Field Type
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Added more detail to definition files for Sample Types and Field Types
-
+- Pulling now adds more complete information to definition.json file
 
 ## -- 2021-02-24 -- [1.1.0] 
 

--- a/pfish-wrapper
+++ b/pfish-wrapper
@@ -8,7 +8,7 @@
 
 PROGNAME="$(basename $0)"
 
-VERSION="1.1.0"
+VERSION="1.2.0"
 
 # Helper functions for guards
 error(){

--- a/pxfish/field_type.py
+++ b/pxfish/field_type.py
@@ -40,25 +40,12 @@ def add_field_type(*, operation_type, definition, role, path, session):
         field_type = session.FieldType.new()
         field_type.role = role
         field_type.name = query['name']
-        field_type.part = definition['part']
-        field_type.array = definition['array']
-        field_type.routing = definition['routing']
-        # Work around for change in definition file
-        additional_attributes = {
-            'ftype': 'sample',
-            'choices': None,
-            'required': None
-                }
-        for attribute in additional_attributes:
-            try:
-                additional_attributes[attribute] = definition[attribute]
-            except KeyError:
-                continue
-
-        if additional_attributes:
-            field_type.ftype = additional_attributes['ftype']
-            field_type.choices = additional_attributes['choices']
-            field_type.required = additional_attributes['required']
+        field_type.part = definition.get('part', None)
+        field_type.array = definition.get('array', None)
+        field_type.routing = definition.get('routing', None)
+        field_type.ftype = definition.get('ftype', 'sample')
+        field_type.choices = definition.get('choices', None)
+        field_type.required = definition.get('required', None)
 
         field_type.allowable_field_types = [
             add_aft(

--- a/pxfish/field_type.py
+++ b/pxfish/field_type.py
@@ -39,11 +39,26 @@ def add_field_type(*, operation_type, definition, role, path, session):
     else:
         field_type = session.FieldType.new()
         field_type.role = role
-        field_type.array = definition['array']
-        field_type.part = definition['part']
-        field_type.routing = definition['routing']
         field_type.name = query['name']
-        field_type.ftype = definition['ftype']
+        field_type.part = definition['part']
+        field_type.array = definition['array']
+        field_type.routing = definition['routing']
+        # Work around for change in definition file
+        additional_attributes = {
+            'ftype': 'sample',
+            'choices': None,
+            'required': None
+                }
+        for attribute in additional_attributes:
+            try:
+                additional_attributes[attribute] = definition[attribute]
+            except KeyError:
+                continue
+
+        if additional_attributes:
+            field_type.ftype = additional_attributes['ftype']
+            field_type.choices = additional_attributes['choices']
+            field_type.required = additional_attributes['required']
 
         field_type.allowable_field_types = [
             add_aft(
@@ -202,6 +217,7 @@ def types_valid(*, operation_type, definitions, force, session):
         definitions=definitions['inputs'],
         force=force
     )
+
     missing_outputs, output_conflicts, valid_outputs = check_for_conflicts(
         field_types=[t for t in field_types if t.role == 'output'],
         definitions=definitions['outputs'],


### PR DESCRIPTION
The latest update creates a definition.json file with some attributes we had not used in the previous version. This adds a workaround so that, if you are using an old definition file, you will not get an error when it tries to read fields that aren't in your file.