### PR TITLE
Use binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Test Files
 TEST*/
+
+# snyk config
+.dccache

--- a/pxfish/code_component.py
+++ b/pxfish/code_component.py
@@ -15,7 +15,7 @@ def write(*, path, file_name, code_object):
       code_object (Code): the code object to be written
     """
     file_path = os.path.join(path, file_name)
-    with open(file_path, 'w') as file:
+    with open(file_path, 'wb') as file:
         file.write(code_object.content)
 
 


### PR DESCRIPTION
The Snyk security check flagged using text mode as an issue with Windows and Python 3.

Managing file format could be a cross platform issue with pfish since the encoding could change b/w Aquarium and users environment.